### PR TITLE
Split builder compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,23 @@ It is written in TypeScript and uses the latest Grafana plugin APIs.
 ### Developer Notes
 
 The project targets **Node.js 20**, **TypeScript 5**, and Grafana **v12**.
-A simple docker-compose setup builds the plugin and starts Grafana:
+A simple docker-compose setup can build the plugin and start Grafana.
+First build the datasource using the dedicated compose file:
 
 ```bash
-docker-compose -f dockerTest/docker-compose-grafana-hapi.yml up
+docker compose -f dockerTest/docker-compose.build.yml run --rm builder
 ```
 
-This starts Grafana together with a HAPI FHIR server populated with test data.
-The `builder` service compiles the plugin before Grafana starts so you always
-run the latest code without installing Node locally.
+This runs a Node 20 container that installs dependencies and executes the
+build command, producing the `dist` directory.
+
+Then start Grafana:
+
+```bash
+docker compose -f dockerTest/docker-compose-grafana-hapi.yml up
+```
+
+Grafana will load the compiled plugin from `dist` without rebuilding it.
 
 ### Build
 

--- a/dockerTest/docker-compose.build.yml
+++ b/dockerTest/docker-compose.build.yml
@@ -1,0 +1,8 @@
+version: '3'
+services:
+  builder:
+    image: node:20
+    working_dir: /build
+    volumes:
+      - ..:/build
+    command: sh -c "npm ci && npm run build"

--- a/dockerTest/docker-compose.yml
+++ b/dockerTest/docker-compose.yml
@@ -1,12 +1,5 @@
 version: '3'
 services:
-  builder:
-    image: node:20
-    working_dir: /build
-    volumes:
-      - ..:/build
-    command: sh -c "npm ci && npm run build"
-
   grafana:
     container_name: grafana
     image: grafana/grafana
@@ -19,5 +12,3 @@ services:
       - "3000:3000"
     expose:
       - "3000"
-    depends_on:
-      - builder


### PR DESCRIPTION
## Summary
- separate builder service into dedicated compose file
- keep Grafana compose file focused on runtime
- document how to build using the new compose file

## Testing
- `bash test.sh` *(fails: docker-compose command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686449cf37808320bf2fcdedf275581a