### PR TITLE
Implement dual-mode query editor

### DIFF
--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -1,54 +1,180 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { QueryEditorProps, SelectableValue } from '@grafana/data';
-import { InlineField, Select, Input, Stack } from '@grafana/ui';
+import { Button, InlineField, Input, Label, Stack, Select } from '@grafana/ui';
 import { DataSource } from '../datasource';
 import { FhirDataSourceOptions, FhirQuery } from '../types';
 
-type Props = QueryEditorProps<DataSource, FhirQuery, FhirDataSourceOptions>;
+interface Props extends QueryEditorProps<DataSource, FhirQuery, FhirDataSourceOptions> {
+  /** Optional callback invoked whenever the raw query string changes */
+  onQueryChange?: (query: string) => void;
+}
 
-export function QueryEditor({ query, datasource, onChange, onRunQuery }: Props) {
+interface FilterRow {
+  param: string;
+  value: string;
+}
+
+export function QueryEditor({
+  query,
+  datasource,
+  onChange,
+  onRunQuery,
+  onQueryChange,
+}: Props) {
+  const [mode, setMode] = useState<'builder' | 'code'>(() => (query.queryString ? 'code' : 'builder'));
+  const [currentQuery, setCurrentQuery] = useState<string>(query.queryString || '');
   const [resources, setResources] = useState<Array<SelectableValue<string>>>([]);
-  const operatorOptions = [
-    { label: '==', value: '==' },
-    { label: '!=', value: '!=' },
-  ];
+  const [searchParams, setSearchParams] = useState<Array<SelectableValue<string>>>([]);
+  const [resource, setResource] = useState<string>('');
+  const [filters, setFilters] = useState<FilterRow[]>([{ param: '', value: '' }]);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    datasource.getResourceTypes().then((types) => setResources(types));
+    datasource.getResourceTypes().then(setResources);
   }, [datasource]);
 
-  const onResourceChange = (v: SelectableValue<string>) => {
-    onChange({ ...query, resourceType: v.value || '' });
-    onRunQuery();
+  useEffect(() => {
+    if (resource) {
+      datasource.getSearchParameters(resource).then(setSearchParams).catch(() => setSearchParams([]));
+    }
+  }, [datasource, resource]);
+
+  const parseQuery = useCallback((qs: string) => {
+    if (!qs) {
+      return { resourceType: '', filters: [] as FilterRow[] };
+    }
+    const [res, params] = qs.split('?');
+    if (!res) {
+      throw new Error('Missing resource type');
+    }
+    const parsed: FilterRow[] = [];
+    if (params) {
+      const search = new URLSearchParams(params);
+      search.forEach((v, k) => {
+        parsed.push({ param: k, value: v });
+      });
+    }
+    return { resourceType: res, filters: parsed };
+  }, []);
+
+  const buildQuery = useCallback((resType: string, fltrs: FilterRow[]) => {
+    if (!resType) {
+      return '';
+    }
+    const parts = fltrs
+      .filter(f => f.param && f.value)
+      .map(f => `${encodeURIComponent(f.param)}=${encodeURIComponent(f.value)}`)
+      .join('&');
+    return parts ? `${resType}?${parts}` : resType;
+  }, []);
+
+  // Keep query string up to date in builder mode
+  useEffect(() => {
+    if (mode === 'builder') {
+      const q = buildQuery(resource, filters);
+      setCurrentQuery(q);
+      onChange({ ...query, queryString: q });
+      onQueryChange?.(q);
+    }
+  }, [mode, resource, filters, buildQuery]);
+
+  const switchMode = useCallback(() => {
+    if (mode === 'code') {
+      try {
+        const parsed = parseQuery(currentQuery);
+        setResource(parsed.resourceType);
+        setFilters(parsed.filters.length > 0 ? parsed.filters : [{ param: '', value: '' }]);
+        setMode('builder');
+        setError(null);
+      } catch (err: any) {
+        setError(err.message);
+      }
+    } else {
+      setMode('code');
+      setError(null);
+    }
+  }, [mode, currentQuery, parseQuery]);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.shiftKey && e.key.toLowerCase() === 'm') {
+        e.preventDefault();
+        switchMode();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [switchMode]);
+
+  const onCodeChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const q = e.target.value;
+    setCurrentQuery(q);
+    onChange({ ...query, queryString: q });
+    onQueryChange?.(q);
   };
 
-  const onParamChange = (v: React.ChangeEvent<HTMLInputElement>) => {
-    onChange({ ...query, searchParam: v.target.value });
+  const addFilter = () => {
+    setFilters([...filters, { param: '', value: '' }]);
   };
 
-  const onOperatorChange = (v: SelectableValue<string>) => {
-    onChange({ ...query, operator: v.value || '==' });
+  const changeParam = (idx: number, value: string) => {
+    const next = filters.slice();
+    next[idx].param = value;
+    setFilters(next);
+  };
+  const changeValue = (idx: number, value: string) => {
+    const next = filters.slice();
+    next[idx].value = value;
+    setFilters(next);
   };
 
-  const onValueChange = (v: React.ChangeEvent<HTMLInputElement>) => {
-    onChange({ ...query, searchValue: v.target.value });
-    onRunQuery();
-  };
+  if (mode === 'code') {
+    return (
+      <Stack direction="column" gap={1} wrap="nowrap">
+        <Input
+          width={40}
+          value={currentQuery}
+          onChange={onCodeChange}
+          placeholder="Patient?name=John"
+        />
+        {error && <Label color="red">{error}</Label>}
+        <Button variant="secondary" size="sm" onClick={switchMode}>
+          » Switch to Builder (Ctrl+⇧+M)
+        </Button>
+      </Stack>
+    );
+  }
 
   return (
-    <Stack gap={1} wrap="nowrap" direction="row">
-      <InlineField label="Resource">
-        <Select options={resources} value={query.resourceType} onChange={onResourceChange} width={20} />
-      </InlineField>
-      <InlineField label="Search">
-        <Input width={20} value={query.searchParam || ''} onChange={onParamChange} placeholder="code" />
-      </InlineField>
-      <InlineField label="Op">
-        <Select options={operatorOptions} value={query.operator} onChange={onOperatorChange} width={8} />
-      </InlineField>
-      <InlineField label="Value">
-        <Input width={20} value={query.searchValue || ''} onChange={onValueChange} placeholder="*" />
-      </InlineField>
+    <Stack direction="column" gap={1} wrap="nowrap">
+      <Stack direction="row" gap={1} wrap="nowrap">
+        <InlineField label="Resource">
+          <Select options={resources} value={resource} onChange={v => setResource(v.value || '')} width={20} />
+        </InlineField>
+      </Stack>
+      {filters.map((f, i) => (
+        <Stack direction="row" gap={1} wrap="nowrap" key={i} alignItems="flex-end">
+          <InlineField label="Search">
+            <Select
+              options={searchParams}
+              value={f.param}
+              onChange={v => changeParam(i, v.value || '')}
+              width={20}
+            />
+          </InlineField>
+          <InlineField label="Value">
+            <Input value={f.value} onChange={e => changeValue(i, e.target.value)} width={20} />
+          </InlineField>
+          {i === filters.length - 1 && (
+            <Button variant="secondary" size="sm" onClick={addFilter}>
+              + Add filter
+            </Button>
+          )}
+        </Stack>
+      ))}
+      <Button variant="secondary" size="sm" onClick={switchMode}>
+        » Switch to Code (Ctrl+⇧+M)
+      </Button>
     </Stack>
   );
 }

--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -33,7 +33,7 @@ describe('DataSource.fetchSeries', () => {
     (getBackendSrv as jest.Mock).mockReturnValue({ fetch });
 
     const ds = new DataSource(makeSettings('http://example.com'));
-    const frame: any = await ds.fetchSeries({ resourceType: 'Patient', refId: 'A' } as any);
+    const frame: any = await ds.fetchSeries({ queryString: 'Patient', refId: 'A' } as any);
 
     expect(fetch).toHaveBeenCalledWith({ url: '/api/datasources/proxy/1/Patient' });
     expect(frame._opts.fields).toEqual([

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,20 @@
 import { DataQuery, DataSourceJsonData } from '@grafana/data';
 
 export interface FhirQuery extends DataQuery {
+  /**
+   * Raw query string in the form `Resource?param=value` as entered in the
+   * editor's code mode. When provided this value takes precedence over the
+   * structured fields below.
+   */
+  queryString?: string;
+
+  /** The resource type to query when using the builder UI */
   resourceType: string;
+  /** Search parameter name */
   searchParam?: string;
+  /** Comparison operator */
   operator?: string;
+  /** Search parameter value */
   searchValue?: string;
 }
 


### PR DESCRIPTION
## Summary
- support raw query string in `FhirQuery`
- handle queryString in datasource and expose search parameters
- add builder+code mode UI for the query editor
- adapt datasource tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6869536fbc7083208d8439799a25957b