### PR TITLE
Add metricFindQuery support

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ npm run build
 Run the build script before manually installing the plugin. Copy the generated
 `dist` directory into Grafana's plugin directory to install it.
 
+### Query editor
+
+The query fields accept Grafana template variables. References like `${patient}`
+are replaced when the query is executed. This works in both code mode and the
+builder UI.
+
 ### Template variables
 
 Template variables can be populated using the datasource's variable query editor.

--- a/README.md
+++ b/README.md
@@ -55,3 +55,6 @@ Or:
 - Resource: `Observation?code=weight`
 - Text field: `subject.reference`
 - Value field: `id`
+
+If a query fails and the FHIR server returns a Bundle with an `issue` element,
+the diagnostics text will be displayed as a toast notification in Grafana.

--- a/README.md
+++ b/README.md
@@ -40,13 +40,18 @@ Run the build script before manually installing the plugin. Copy the generated
 
 ### Template variables
 
-Template variables can be populated using the datasource's `metricFindQuery` implementation.
-Provide a string in the form `ResourceType|textField|valueField` and the datasource
-will fetch the resources and map each one to a text/value pair using the specified fields.
+Template variables can be populated using the datasource's variable query editor.
+Specify the **Resource**, **Text field**, and **Value field** separately. The datasource
+will fetch matching resources and map each to a text/value pair using the selected fields.
 
-Example:
+Example fields:
 
-```
-Patient|name[0].family|id
-Observation?code=weight|subject.reference|id
-```
+- Resource: `Patient`
+- Text field: `name[0].family`
+- Value field: `id`
+
+Or:
+
+- Resource: `Observation?code=weight`
+- Text field: `subject.reference`
+- Value field: `id`

--- a/README.md
+++ b/README.md
@@ -44,10 +44,20 @@ Template variables can be populated using the datasource's variable query editor
 Specify the **Resource**, **Text field**, and **Value field** separately. The datasource
 will fetch matching resources and map each to a text/value pair using the selected fields.
 
+The **Text field** may contain a comma separated list of JSON paths. Each value is
+looked up and combined with spaces to form the final text shown in the variable.
+Run the query using the **Run query** button to fetch results.
+
 Example fields:
 
 - Resource: `Patient`
 - Text field: `name[0].family`
+- Value field: `id`
+
+Or with multiple text fields:
+
+- Resource: `Patient`
+- Text field: `name[0].given[0], name[0].family`
 - Value field: `id`
 
 Or:

--- a/README.md
+++ b/README.md
@@ -37,3 +37,16 @@ npm run build
 ```
 Run the build script before manually installing the plugin. Copy the generated
 `dist` directory into Grafana's plugin directory to install it.
+
+### Template variables
+
+Template variables can be populated using the datasource's `metricFindQuery` implementation.
+Provide a string in the form `ResourceType|textField|valueField` and the datasource
+will fetch the resources and map each one to a text/value pair using the specified fields.
+
+Example:
+
+```
+Patient|name[0].family|id
+Observation?code=weight|subject.reference|id
+```

--- a/src/components/VariableQueryEditor.tsx
+++ b/src/components/VariableQueryEditor.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { DataSourceVariableQueryEditorProps } from '@grafana/data';
+import { InlineField, Input, Stack } from '@grafana/ui';
+import { DataSource } from '../datasource';
+
+interface VariableQuery {
+  resource?: string;
+  textField?: string;
+  valueField?: string;
+}
+
+export function VariableQueryEditor({ query, onChange }: DataSourceVariableQueryEditorProps<DataSource>) {
+  const q = (query || {}) as VariableQuery;
+
+  const update = (patch: Partial<VariableQuery>) => {
+    const next = { ...q, ...patch };
+    const definition = `${next.resource || ''}|${next.textField || ''}|${next.valueField || ''}`;
+    onChange(next, definition);
+  };
+
+  return (
+    <Stack direction="column" gap={1} wrap="nowrap">
+      <InlineField label="Resource">
+        <Input value={q.resource || ''} onChange={e => update({ resource: e.currentTarget.value })} width={20} />
+      </InlineField>
+      <InlineField label="Text field">
+        <Input value={q.textField || ''} onChange={e => update({ textField: e.currentTarget.value })} width={20} />
+      </InlineField>
+      <InlineField label="Value field">
+        <Input value={q.valueField || ''} onChange={e => update({ valueField: e.currentTarget.value })} width={20} />
+      </InlineField>
+    </Stack>
+  );
+}

--- a/src/components/VariableQueryEditor.tsx
+++ b/src/components/VariableQueryEditor.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { DataSourceVariableQueryEditorProps } from '@grafana/data';
-import { InlineField, Input, Stack } from '@grafana/ui';
+import { InlineField, Input, Stack, Button } from '@grafana/ui';
 import { DataSource } from '../datasource';
 
 interface VariableQuery {
@@ -9,26 +9,40 @@ interface VariableQuery {
   valueField?: string;
 }
 
-export function VariableQueryEditor({ query, onChange }: DataSourceVariableQueryEditorProps<DataSource>) {
+export function VariableQueryEditor({ query, onChange, onRunQuery }: DataSourceVariableQueryEditorProps<DataSource>) {
   const q = (query || {}) as VariableQuery;
 
-  const update = (patch: Partial<VariableQuery>) => {
-    const next = { ...q, ...patch };
-    const definition = `${next.resource || ''}|${next.textField || ''}|${next.valueField || ''}`;
+  const [resource, setResource] = useState(q.resource || '');
+  const [textField, setTextField] = useState(q.textField || '');
+  const [valueField, setValueField] = useState(q.valueField || '');
+
+  useEffect(() => {
+    setResource(q.resource || '');
+    setTextField(q.textField || '');
+    setValueField(q.valueField || '');
+  }, [q.resource, q.textField, q.valueField]);
+
+  const run = () => {
+    const next = { resource, textField, valueField };
+    const definition = `${resource}|${textField}|${valueField}`;
     onChange(next, definition);
+    onRunQuery();
   };
 
   return (
     <Stack direction="column" gap={1} wrap="nowrap">
       <InlineField label="Resource">
-        <Input value={q.resource || ''} onChange={e => update({ resource: e.currentTarget.value })} width={20} />
+        <Input value={resource} onChange={e => setResource(e.currentTarget.value)} width={20} />
       </InlineField>
       <InlineField label="Text field">
-        <Input value={q.textField || ''} onChange={e => update({ textField: e.currentTarget.value })} width={20} />
+        <Input value={textField} onChange={e => setTextField(e.currentTarget.value)} width={20} />
       </InlineField>
       <InlineField label="Value field">
-        <Input value={q.valueField || ''} onChange={e => update({ valueField: e.currentTarget.value })} width={20} />
+        <Input value={valueField} onChange={e => setValueField(e.currentTarget.value)} width={20} />
       </InlineField>
+      <Button variant="secondary" size="sm" onClick={run}>
+        Run query
+      </Button>
     </Stack>
   );
 }

--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -164,6 +164,18 @@ describe('DataSource.metricFindQuery', () => {
     expect(res).toEqual([{ text: 'Patient/1', value: 'obs1' }]);
   });
 
+  it('combines multiple text fields', async () => {
+    const fetch = jest.fn().mockReturnValue(
+      of({ data: { entry: [
+        { resource: { id: '1', name: [{ given: ['Alice'], family: 'Smith' }] } },
+      ] } })
+    );
+    (getBackendSrv as jest.Mock).mockReturnValue({ fetch });
+    const ds = new DataSource(makeSettings('http://example.com'));
+    const res = await ds.metricFindQuery('Patient|name[0].given[0], name[0].family|id');
+    expect(res).toEqual([{ text: 'Alice Smith', value: '1' }]);
+  });
+
   it('shows toast when response has issue', async () => {
     const fetch = jest.fn().mockReturnValue(
       of({ data: { issue: [{ diagnostics: 'bad request' }] } })

--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -142,7 +142,7 @@ describe('DataSource.metricFindQuery', () => {
     );
     (getBackendSrv as jest.Mock).mockReturnValue({ fetch });
     const ds = new DataSource(makeSettings('http://example.com'));
-    const res = await ds.metricFindQuery('Patient|name[0].family|id');
+    const res = await ds.metricFindQuery({ resource: 'Patient', textField: 'name[0].family', valueField: 'id' });
     expect(fetch).toHaveBeenCalledWith({ url: '/api/datasources/proxy/1/Patient' });
     expect(res).toEqual([
       { text: 'Smith', value: '1' },
@@ -158,7 +158,7 @@ describe('DataSource.metricFindQuery', () => {
     );
     (getBackendSrv as jest.Mock).mockReturnValue({ fetch });
     const ds = new DataSource(makeSettings('http://example.com'));
-    const res = await ds.metricFindQuery('Observation|subject.reference|id');
+    const res = await ds.metricFindQuery({ resource: 'Observation', textField: 'subject.reference', valueField: 'id' });
     expect(res).toEqual([{ text: 'Patient/1', value: 'obs1' }]);
   });
 });

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -1,7 +1,7 @@
 import { DataSourceApi, DataSourceInstanceSettings, DataQueryRequest, DataQueryResponse, MutableDataFrame, FieldType, MetricFindValue, AppEvents } from '@grafana/data';
 import { getBackendSrv, getAppEvents } from '@grafana/runtime';
 import { firstValueFrom } from 'rxjs';
-import get = require('lodash/get');
+import * as lodash from 'lodash';
 import { FhirQuery, FhirDataSourceOptions, DEFAULT_QUERY } from './types';
 import { isTimeSeriesResource, extractDatapoints, pointsToDataFrame, TimeSeriesPoint } from './timeseries';
 
@@ -158,7 +158,7 @@ export class DataSource extends DataSourceApi<FhirQuery, FhirDataSourceOptions> 
       }
 
       const resources = (res.data.entry || []).map((e: any) => e.resource || {});
-      return resources.map((r: any) => ({ text: get(r, textField!), value: get(r, valueField!) }));
+      return resources.map((r: any) => ({ text: lodash.get(r, textField!), value: lodash.get(r, valueField!) }));
     } catch (err: any) {
       const detail = err?.statusText || err?.message;
       (getAppEvents() as any)?.emit(AppEvents.alertError, ['FHIR query error', detail]);

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -1,7 +1,7 @@
 import { DataSourceApi, DataSourceInstanceSettings, DataQueryRequest, DataQueryResponse, MutableDataFrame, FieldType, MetricFindValue, AppEvents } from '@grafana/data';
 import { getBackendSrv, getAppEvents } from '@grafana/runtime';
 import { firstValueFrom } from 'rxjs';
-import { get } from 'lodash';
+import get = require('lodash/get');
 import { FhirQuery, FhirDataSourceOptions, DEFAULT_QUERY } from './types';
 import { isTimeSeriesResource, extractDatapoints, pointsToDataFrame, TimeSeriesPoint } from './timeseries';
 

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -159,7 +159,11 @@ export class DataSource extends DataSourceApi<FhirQuery, FhirDataSourceOptions> 
       }
 
       const resources = (res.data.entry || []).map((e: any) => e.resource || {});
-      return resources.map((r: any) => ({ text: lodashGet(r, textField!), value: lodashGet(r, valueField!) }));
+      const textPaths = textField!.split(',').map(p => p.trim()).filter(Boolean);
+      return resources.map((r: any) => ({
+        text: textPaths.map(p => lodashGet(r, p)).filter(v => v != null).join(' '),
+        value: lodashGet(r, valueField!),
+      }));
     } catch (err: any) {
       const detail = err?.statusText || err?.message;
       (getAppEvents() as any)?.emit(AppEvents.alertError, ['FHIR query error', detail]);

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -1,4 +1,4 @@
-import { DataSourceApi, DataSourceInstanceSettings, DataQueryRequest, DataQueryResponse, MutableDataFrame, FieldType, SelectableValue } from '@grafana/data';
+import { DataSourceApi, DataSourceInstanceSettings, DataQueryRequest, DataQueryResponse, MutableDataFrame, FieldType, SelectableValue, MetricFindValue } from '@grafana/data';
 import { getBackendSrv } from '@grafana/runtime';
 import { firstValueFrom } from 'rxjs';
 import { get } from 'lodash';
@@ -132,12 +132,12 @@ export class DataSource extends DataSourceApi<FhirQuery, FhirDataSourceOptions> 
     }
   }
 
-  async metricFindQuery(query: string) {
-    const [resourceQuery, textField, valueField] = query.split('|').map(p => p.trim());
-    if (!resourceQuery || !textField || !valueField) {
+  async metricFindQuery(query: { resource?: string; textField?: string; valueField?: string }): Promise<MetricFindValue[]> {
+    const { resource, textField, valueField } = query || {};
+    if (!resource || !textField || !valueField) {
       return [];
     }
-    const url = `${this.getBaseUrl()}/${resourceQuery}`;
+    const url = `${this.getBaseUrl()}/${resource}`;
     const res = await firstValueFrom(getBackendSrv().fetch<any>({ url }));
     const resources = (res.data.entry || []).map((e: any) => e.resource || {});
     return resources.map((r: any) => ({ text: get(r, textField), value: get(r, valueField) }));

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -2,6 +2,7 @@ import { DataSourceApi, DataSourceInstanceSettings, DataQueryRequest, DataQueryR
 import { getBackendSrv, getAppEvents } from '@grafana/runtime';
 import { firstValueFrom } from 'rxjs';
 import * as lodash from 'lodash';
+const lodashGet: any = (lodash as any).get || (lodash as any).default?.get;
 import { FhirQuery, FhirDataSourceOptions, DEFAULT_QUERY } from './types';
 import { isTimeSeriesResource, extractDatapoints, pointsToDataFrame, TimeSeriesPoint } from './timeseries';
 
@@ -158,7 +159,7 @@ export class DataSource extends DataSourceApi<FhirQuery, FhirDataSourceOptions> 
       }
 
       const resources = (res.data.entry || []).map((e: any) => e.resource || {});
-      return resources.map((r: any) => ({ text: lodash.get(r, textField!), value: lodash.get(r, valueField!) }));
+      return resources.map((r: any) => ({ text: lodashGet(r, textField!), value: lodashGet(r, valueField!) }));
     } catch (err: any) {
       const detail = err?.statusText || err?.message;
       (getAppEvents() as any)?.emit(AppEvents.alertError, ['FHIR query error', detail]);

--- a/src/module.ts
+++ b/src/module.ts
@@ -2,8 +2,10 @@ import { DataSourcePlugin } from '@grafana/data';
 import { DataSource } from './datasource';
 import { ConfigEditor } from './components/ConfigEditor';
 import { QueryEditor } from './components/QueryEditor';
+import { VariableQueryEditor } from './components/VariableQueryEditor';
 import { FhirQuery, FhirDataSourceOptions } from './types';
 
 export const plugin = new DataSourcePlugin<DataSource, FhirQuery, FhirDataSourceOptions>(DataSource)
   .setConfigEditor(ConfigEditor)
-  .setQueryEditor(QueryEditor);
+  .setQueryEditor(QueryEditor)
+  .setVariableQueryEditor(VariableQueryEditor);


### PR DESCRIPTION
## Summary
- implement `metricFindQuery` in datasource
- add tests for new function
- document template variable usage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686a806c979c83209a4515b96d3b8b9c