### PR TITLE
Add developer docs and contribution guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,17 @@
+# Contributing
+
+Thank you for wanting to contribute! Development requires **Node.js 20** and npm.
+The main commands are:
+
+```bash
+npm ci        # install dependencies
+npm run build # compile the plugin to ./dist
+npm test      # run the Jest test suite
+```
+
+Please ensure the tests pass before submitting a pull request.
+
+1. Fork the repository and create a feature branch.
+2. Make your changes following the existing TypeScript code style.
+3. Run `npm test` and `npm run build`.
+4. Open a pull request describing your changes.

--- a/DEVELOPER_OVERVIEW.md
+++ b/DEVELOPER_OVERVIEW.md
@@ -1,0 +1,34 @@
+# Developer Overview
+
+This project implements a Grafana datasource that queries FHIR compliant servers.
+It is written in TypeScript and packaged as a Grafana plugin.
+
+## Repository layout
+
+- **src/** – TypeScript sources for the plugin
+  - `components/` – React components used by Grafana (editors and UI)
+  - `datasource.ts` – main datasource implementation
+  - `timeseries.ts` – helpers for converting FHIR resources into time series data
+  - `utils/` – small helper modules and scripts
+- **synthetic-data/** – example FHIR resources used with the test Docker setup
+- **dockerTest/** – docker-compose files to build the plugin and run Grafana with a HAPI FHIR server
+- **specs/** – helper files used by the Jest test suite
+- **dist/** – output directory created when building the plugin (not tracked)
+
+## Datasource functionality
+
+The datasource talks to a configurable FHIR base URL. Queries can be entered in a
+simple builder UI or in raw form using `Resource?param=value` syntax. Requests are
+made either directly or through Grafana's proxy depending on the datasource
+settings. Responses are mapped to Grafana data frames:
+
+- Tabular frames contain the returned resources with one column per field.
+- Time series frames are generated when the resources represent observations,
+  medication administrations or conditions. Relevant values are extracted and
+  normalised for display.
+
+Template variables are supported in both query strings and search values. The
+plugin also provides a variable query editor that maps FHIR resources to
+`text/value` pairs for populating dashboard variables.
+
+Automated tests are written with Jest and can be run via `npm test`.

--- a/README.md
+++ b/README.md
@@ -74,3 +74,5 @@ Or:
 
 If a query fails and the FHIR server returns a Bundle with an `issue` element,
 the diagnostics text will be displayed as a toast notification in Grafana.
+See [DEVELOPER_OVERVIEW.md](DEVELOPER_OVERVIEW.md) for repository details and [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines.
+


### PR DESCRIPTION
## Summary
- document repository structure and datasource features
- add a CONTRIBUTING guide for new developers
- link the docs from the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686b63c95a6483208f7ba68d030fe163